### PR TITLE
fix Soramitsu polkaswap GitHub link

### DIFF
--- a/grants/accepted_grant_applications.md
+++ b/grants/accepted_grant_applications.md
@@ -132,5 +132,5 @@ This page gives an overview of accepted grants and a link to their GitHubs. Keep
 - [Crust Network](https://crust.network/) - Incentive layer protocol for decentralized storage ([GitHub](https://github.com/crustio))
 - [ETCDEV](https://emeraldpay.io/) - Polkadot Java Client ([GitHub](https://github.com/emeraldpay))
 - [Zondax](http://zondax.ch/) - Ledger app for Polkadot/Kusama Phase 2 ([GitHub](https://github.com/ZondaX/ledger-polkadot))
-- [Soramitsu](https://soramitsu.co.jp/) - Polkaswap - “Uniswap” for the Polkadot ecosystem ([GitHub](https://github.com/soramitsu/polkaswap))
+- [Soramitsu](https://soramitsu.co.jp/) - Polkaswap - “Uniswap” for the Polkadot ecosystem ([GitHub](https://github.com/sora-xor/polkaswap-web))
 - [LimeChain](https://github.com/LimeChain) - AssemblyScript SCALE Codec ([GitHub](https://github.com/LimeChain))


### PR DESCRIPTION
set polkaswap githupb link to the correct repository
