### PR TITLE
Add a few items to Polkadot stack page

### DIFF
--- a/grants/polkadot_stack.md
+++ b/grants/polkadot_stack.md
@@ -137,7 +137,7 @@ In the below sections you can find a list of different layers of the Polkadot St
 
 | Components | Existing projects | Potentially interesting projects
 |-|-|-
-| SR25519 | [rust](https://github.com/w3f/schnorrkel) (contains partial bindings for C, JavaScript, and Python), [C](https://github.com/usetech-llc/sr25519) *(old)*, [C](https://github.com/TerenceGe/sr25519-donna) *(new)*,  [C#](https://github.com/usetech-llc/sr25519_dotnet), [java](https://github.com/debuggor/schnorrkel-java)
+| SR25519 | [rust](https://github.com/w3f/schnorrkel) (contains partial bindings for C, JavaScript, and Python), [C](https://github.com/usetech-llc/sr25519) *(old)*, [C](https://github.com/TerenceGe/sr25519-donna) *(new)*, [C/C++](https://github.com/Harrm/sr25519-crust), [C#](https://github.com/usetech-llc/sr25519_dotnet), [Go](https://github.com/ChainSafe/go-schnorrkel), [java](https://github.com/debuggor/schnorrkel-java)
 | Easy multisig scheme | 
 | Validator HSMs| |
 | Validator HSM-like solutions|

--- a/grants/polkadot_stack.md
+++ b/grants/polkadot_stack.md
@@ -117,7 +117,7 @@ In the below sections you can find a list of different layers of the Polkadot St
 
 | Components | Existing projects | Potentially interesting projects
 |-|-|-
-| Rust | [Substrate](https://github.com/paritytech/substrate)
+| Rust | [Substrate](https://github.com/paritytech/substrate), [Cumulus](https://github.com/paritytech/cumulus)
 | C++ | [Kagome](https://github.com/soramitsu/kagome)
 | Go | [Gossamer](https://github.com/ChainSafe/gossamer)
 | AssemblyScript | 


### PR DESCRIPTION
This PR add the following three items to the stack page:

 - [cumulus](https://github.com/paritytech/cumulus)
 - [sr25519-crust](https://github.com/Harrm/sr25519-crust) 
 - [go-schnorrkel](https://github.com/ChainSafe/go-schnorrkel)