### PR TITLE
adds DKG and Randomness Beacon pallets to the polkadot_stack list

### DIFF
--- a/grants/polkadot_stack.md
+++ b/grants/polkadot_stack.md
@@ -115,6 +115,7 @@ In the below sections you can find a list of different layers of the Polkadot St
 | Computation | 
 | Enable specific use-cases | [Robonomics](https://github.com/airalab/substrate-node-robonomics)
 | NFT | [FRAME Pallet: NFTs for Substrate](https://github.com/danforbes/pallet-nft), [NFT Parachain by usetech](https://github.com/w3f-community/nft_parachain)
+| Randomness | [DKG and Randomness Beacon](https://github.com/Cardinal-Cryptography/substrate/tree/randomness-beacon)
 | Licensing |
 | Other | [Substrate Open Runtime Module Library](https://github.com/open-web3-stack/open-runtime-module-library) | On-chain quadratic funding (e.g. https://clr.fund/#/about)
 


### PR DESCRIPTION
Adding info about the project that we have just finished and that was founded by [the grant](https://github.com/w3f/General-Grants-Program/blob/727a960f3965c07ba6cc51722d499d27328cdce9/grants/speculative/Threshold%20BLS%20Randomness%20Beacon%20for%20Substrate.md).

I couldn't figure out the ordering of the Chains and Modules section, hopefully what I propose is a good place. If not, please, let me know.