### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Below is list of other grant programs in the polkadot/substrate ecosystem:
 
 - [Darwinia Grants Program](https://docs.darwinia.network/docs/en/dev-bounty#grant-program) 
 - [Moonbeam Grants Program](https://moonbeam.network/community/grants/)
+- [Edgeware Grants and Bounties](https://github.com/edgeware-builders/construction-projects)
 
 ## :bulb: Help
 


### PR DESCRIPTION
Adds Edgeware Grants and Bounties link under Other Grant Programs header.

