### PR TITLE
Rename PureStake to Moonbeam

### DIFF
--- a/grants/accepted_grant_applications.md
+++ b/grants/accepted_grant_applications.md
@@ -343,7 +343,7 @@
 | [PolkaMusic](https://polkamusic.io/) | Operating decentralized music businesses on blockchain | [GitHub](https://github.com/polkamusic/PolkaMusic) | <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> |
 | [element36](https://element36.io) | FIAT on-off-ramp | [GitHub](https://github.com/element36-io) | <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> | 
 | [Zondax](https://zondax.ch/) | Ledger Asset App | [GitHub](https://github.com/Zondax) | <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> | 
-| [PureStake](https://www.purestake.com/) | Pallet-dPoS for Parachain Staking | [GitHub](https://github.com/PureStake) | <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> | 
+| [Moonbeam Network](https://moonbeam.network/) | Pallet-dPoS for Parachain Staking | [GitHub](https://github.com/PureStake/moonbeam) | <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> |  <ul><li>[ ] </li></ul> | 
 
 
 


### PR DESCRIPTION
I think they might prefer this since they're applying [under this name](https://github.com/PureStake/Open-Grants-Program/blob/e6c00e1e0eecab64d283a4ee54b8e2d17ce0e8aa/applications/parachain-staking.md#open-grant-proposal) themselves.