### PR TITLE
Add HydraDX Bounties to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Below is a list of other grant programs in the Polkadot/Substrate ecosystem:
 - [Moonbeam Grants Program](https://moonbeam.network/community/grants/)
 - [Edgeware Grants and Bounties](https://github.com/edgeware-builders/construction-projects)
 - [Crust Grants Program](https://github.com/crustio/Crust-Grants-Program)
+- [HydraDX Grants and Bounties](https://docs.hydradx.io/new_deal)
 
 ## :information_source: License <!-- omit in toc -->
 


### PR DESCRIPTION
This PR adds the HydraDX Grants and Bounties program to the section `Other Grant Programs` in `README.md`