### PR TITLE
Add alternative consensus algorithms to tech stack

### DIFF
--- a/grants/polkadot_stack.md
+++ b/grants/polkadot_stack.md
@@ -15,6 +15,7 @@ This is a living document and we are relying on our community to contribute to i
   - [:black_circle: Host](#black_circle-host)
   - [:electric_plug: Network Maintenance Tools](#electric_plug-network-maintenance-tools)
   - [:black_nib: Signatures](#black_nib-signatures)
+  - [✔️ Consensus Alternatives](#heavy_check_mark-consensus-alternatives)
   - [:satellite: Networking](#satellite-networking)
 - [:construction_worker: Contributing](#construction_worker-contributing)
 
@@ -151,6 +152,12 @@ In the below sections you can find a list of different layers of the Polkadot St
 | Distributed key generation (DKG) | [keygen.rs](https://github.com/isislovecruft/frost-dalek)
 | Validator HSMs| |
 | Validator HSM-like solutions|
+
+### ✔️ Consensus Alternatives
+
+| Components | Existing projects | Potentially interesting projects
+|-|-|-
+| PoC | [Spartan](https://github.com/subspace/substrate) |
 
 ### :satellite: Networking
 


### PR DESCRIPTION
@Noc2 feel free to suggest changes. Not sure if I should list those from Substrate as well or if the "alternatives" is necessary.