### PR TITLE
Remove mention of General Grants from grants/grants.md

### DIFF
--- a/grants/grants.md
+++ b/grants/grants.md
@@ -1,4 +1,3 @@
 # General Grants Program
 
-This repository has been deprecated in favour of the [Grants Program repository](https://github.com/w3f/Grants-Program/). You can still apply for a General Grant - to do so, follow the steps outlined in the Grants Program's README.
-
+This repository has been deprecated in favour of the [Grants Program repository](https://github.com/w3f/Grants-Program/).


### PR DESCRIPTION
Inaccurate since people can no longer apply for a general grant - alternatively we could say that they can apply _under the same conditions_ or something, but I think this is also fine.